### PR TITLE
Add OpalOPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 * [WebReaver](http://www.webreaver.com/) \- Web application vulnerability scanner for Mac OS X
 * [DVCS Ripper](https://github.com/kost/dvcs-ripper) \- Rip web accessible (distributed) version control systems: SVN/GIT/HG/BZR
 * [arachni](https://github.com/Arachni/arachni) \- Web Application Security Scanner Framework
+* [OpalOPC](https://opalopc.com/) \- OPC UA vulnerability and misconfiguration scanner
 
 
 * **Network Tools**  


### PR DESCRIPTION
OpalOPC is a vulnerability scanner developed by myself. It targets the OT protocol OPC UA.

It is free for non-commercial use.